### PR TITLE
fix:torch2trt Dockerfile

### DIFF
--- a/docker/torch2trt/Dockerfile
+++ b/docker/torch2trt/Dockerfile
@@ -1,2 +1,1 @@
 FROM wamvtan/yolox
-RUN mkdir model


### PR DESCRIPTION
When run `sh convert.sh` in `docker/torch2trt`, this error occurred.

![image](https://user-images.githubusercontent.com/33048729/180113044-828c98b0-db3b-4062-999d-03eab6a1d054.png)

I fixed this error.