### PR TITLE
add link of install instruction of dependencies

### DIFF
--- a/docs/docs/tools/tools.md
+++ b/docs/docs/tools/tools.md
@@ -2,9 +2,9 @@
 
 ## Train yolox model
 ### Requirement
-- docker
+- [docker](https://docs.docker.com/desktop/install/ubuntu/#install-docker-desktop)
 - docker-compose
-- nvidia-docker
+- [nvidia-docker2](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#setting-up-nvidia-container-toolkit)
 - nvidia-gpu (hardware)
 
 ```
@@ -71,9 +71,9 @@ train_yolox_container |  Average Recall     (AR) @[ IoU=0.50:0.95 | area= large 
 
 ## Convert yolox pytorch model into tensorrt model.
 ### Requirement
-- docker
+- [docker](https://docs.docker.com/desktop/install/ubuntu/#install-docker-desktop)
 - docker-compose
-- nvidia-docker
+- [nvidia-docker2](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#setting-up-nvidia-container-toolkit)
 - nvidia-gpu (hardware)
 
 ```


### PR DESCRIPTION
I update tutorial pages.
Two major changes have been made.
One is `nvidia-docker` to `nvidia-docker2`.
Another is to add a link of install instructions of dependencies.
If this branch is merged, it will make it easier for users to access the installation procedure for dependencies.